### PR TITLE
[docs] Get rid of Angular 2+ notation and enforce linter rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 # testcafe-angular-selectors
 
-This plugin provides [Selector](https://devexpress.github.io/testcafe/documentation/test-api/selecting-page-elements/selectors.html) extensions that make it easier to test Angular applications with [TestCafe](https://github.com/DevExpress/testcafe/). 
+This plugin provides [Selector](https://devexpress.github.io/testcafe/documentation/test-api/selecting-page-elements/selectors.html) extensions that make it easier to test Angular applications with [TestCafe](https://github.com/DevExpress/testcafe/).
 These extensions allow you to create a `Selector` to find elements on the page in a way that is native to Angular applications.
 
 ## Install
 
-```
+```sh
 npm install testcafe-angular-selectors
 ```
 
 ## Usage
 
-This module includes separate helpers for AngularJS(1.x) and Angular(2+) applications.
+This module includes separate helpers for Angular and AngularJS applications.
 
 See the following topics for more details:
-* [AngularJS(1.x) Selector extentions](./angularJS-selector.md)
-* [Angular(2+) Selector extentions](./angular-selector.md)
+
+* [Angular Selector extentions](./angular-selector.md)
+* [AngularJS Selector extentions](./angularJS-selector.md)
 
 ## Examples
 
@@ -43,4 +44,4 @@ fixture `App tests`
 test('test', async t => {
     const firstListItem = AngularSelector('list list-item');
 });
-``` 
+```

--- a/angular-selector.md
+++ b/angular-selector.md
@@ -1,6 +1,7 @@
 # Angular Selector Extentions
 
 ## Prerequisites
+
 Ensure that your application is bootstrapped in the development mode.
 By default, this is true, unless the code contains the [enableProdMode](https://angular.io/api/core/enableProdMode) method call.
 
@@ -26,9 +27,11 @@ Default timeout for `waitForAngular` is 10000 ms.
 You can specify a custom timeout value - `waitForAngular (5000)`.
 
 ### Create selectors for Angular components
+
 `AngularSelector` allows you to select an HTML element by Angular's component selector or nested component selectors.
 
 Suppose you have the following markup
+
 ```html
 <my-app id="data">
     <list id="list1"></list>
@@ -43,12 +46,13 @@ import { AngularSelector } from 'testcafe-angular-selectors';
 ...
 const rootAngular = AngularSelector();
 ```
+
 The rootAngular variable will contain the `<my-app>` element.
 
 > If your application has multiple roots, `AngularSelector` will return the first root returned by the `window.getAllAngularRootElements` function
- 
 
 To get a root DOM element for a component, pass the component selector to the `AngularSelector` constructor.
+
 ```js
 import { AngularSelector } from 'testcafe-angular-selectors';
 
@@ -56,6 +60,7 @@ const listComponent = AngularSelector('list');
 ```
 
 To obtain a nested component, you can use a combined selector.
+
 ```js
 import { AngularSelector } from 'testcafe-angular-selectors';
 
@@ -92,7 +97,7 @@ const listAngular = await list.getAngular();
 await t.expect(listAngular.testProp).eql(1);
 ```
 
-As an alternative, the `.getAngular()` method can take a function that returns the required state property. 
+As an alternative, the `.getAngular()` method can take a function that returns the required state property.
 This function acts as a filter. Its argument is an object returned by `.getAngular()`, i.e. `{ state: ...}`.
 
 ```js


### PR DESCRIPTION
\cc @kirovboris @miherlosev 